### PR TITLE
Add a Popup for restricted pages

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -13,3 +13,5 @@ alwaysApply: true
 - When running end-to-end (e2e) playwright tests, usually you don't need to run `npm run dev` since I'm already running that in the background.
 
 - To search for datadog logs, use `uv run scripts/datadog.py`. Use --help to see how to use it.
+
+- When designing new pages, look at shared.css for style-related standards. (Colors, fonts, etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Improvements
 
+- Add a popup on pages where the extension is restricted by Chrome, to let the user know why they can't rename those tabs.
 - Reduced memory footprint of the emojis asset.
 
 ## [1.1.4] - 2025-05-05

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,12 @@
 
 # Development
 
-# Datadog Logs
+## Pre-publication Checklist
+
+- Compile the `changelog.html` file, using the .md file.
+- `npm version`
+
+## Datadog Logs
 
 Running The Agent:
 ```

--- a/src/assets/changelog.css
+++ b/src/assets/changelog.css
@@ -1,0 +1,8 @@
+.header.changelog-header {
+    margin-bottom: 32px;
+}
+
+h2.version {
+    margin-top: 24px;
+}
+

--- a/src/assets/changelog.html
+++ b/src/assets/changelog.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>What's New</title>
     <link rel="stylesheet" type="text/css" href="shared.css">
+    <link rel="stylesheet" type="text/css" href="changelog.css">
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -16,16 +17,19 @@
 </head>
 <body>
     <div class="container">
-        <h1>What's New</h1>
+        <div class="header changelog-header">
+            <img src="icon128.png" alt="Tab Renamer Logo" class="logo">
+            <h1>What's New</h1>
+        </div>
 
-        <h2>[1.1.4] - 2025-05-05</h2>
+        <h2 class="version">[1.1.4] - 2025-05-05</h2>
 
         <h3>Fixed</h3>
         <ul>
             <li>🛠️ <strong>Regression Fix for Title Retrieval after Chrome Update</strong>: Fixed a regression where the extension would not correctly load stored titles and favicons after a Chrome update or abrupt restart. Added robust testing to prevent future occurrences.</li>
         </ul>
 
-        <h2>[1.1.3] - 2025-04-13</h2>
+        <h2 class="version">[1.1.3] - 2025-04-13</h2>
 
         <h3>Fixed</h3>
         <ul>
@@ -34,7 +38,7 @@
             </li>
         </ul>
 
-        <h2>[1.1.2] - 2025-02-23</h2>
+        <h2 class="version">[1.1.2] - 2025-02-23</h2>
 
         <h3>Added</h3>
         <ul>
@@ -47,14 +51,14 @@
             <li>Partially fixed keystores not being captured appropriately while typing the tab name in some webpages. More fixes to come.</li>
         </ul>
 
-        <h2>[1.0.1] - 2024-06-09</h2>
+        <h2 class="version">[1.0.1] - 2024-06-09</h2>
 
         <h3>Fixed</h3>
         <ul>
             <li>Resolved an issue where the extension would not correctly load stored names and favicons after a Chrome update.</li>
         </ul>
 
-        <h2>[1.0.0] - 2024-05-13</h2>
+        <h2 class="version">[1.0.0] - 2024-05-13</h2>
 
         <h3>Initial Release</h3>
         <ul>

--- a/src/assets/shared.css
+++ b/src/assets/shared.css
@@ -1,7 +1,69 @@
+/* ============================================
+   TAB RENAMER - DESIGN SYSTEM
+   ============================================ */
+
+:root {
+    /* === BRAND COLORS === */
+    --color-primary: #3c79dc;
+    --color-primary-dark: #2a5db0;
+    --color-primary-light: #5a94e8;
+    
+    /* === ACCENT COLOR === */
+    --color-accent: #e1b545;
+    --color-accent-dark: #c99e2e;
+    
+    /* === BACKGROUNDS & SURFACES === */
+    --color-background: #f4f4f4;
+    --color-surface: #ffffff;
+    --color-surface-elevated: #f4f4f4;
+    
+    /* === TEXT === */
+    --color-text: #333333;
+    --color-text-muted: #666666;
+    --color-text-light: #999999;
+    
+    /* === BORDERS === */
+    --color-border: rgba(0, 0, 0, 0.1);
+    
+    /* === TYPOGRAPHY === */
+    --font-display: 'Pacifico', cursive;
+    --font-heading: 'Protest Riot', cursive;
+    --font-body: 'Lato', sans-serif;
+    --font-system: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    
+    --font-size-base: 16px;
+    --font-size-sm: 13px;
+    --font-size-xs: 12px;
+    --font-size-lg: 1.2em;
+    --font-size-xl: 1.5em;
+    --font-size-2xl: 2.6em;
+    
+    --line-height-base: 1.6;
+    --line-height-tight: 1.4;
+    
+    /* === SPACING === */
+    --space-xs: 4px;
+    --space-sm: 8px;
+    --space-md: 16px;
+    --space-lg: 20px;
+    --space-xl: 30px;
+    
+    /* === BORDERS & SHADOWS === */
+    --border-radius-sm: 5px;
+    --border-radius-md: 8px;
+    --border-radius-lg: 30px;
+    --shadow-card: 0px 0px 10px rgba(0, 0, 0, 0.1);
+}
+
+/* ============================================
+   BASE STYLES
+   ============================================ */
+
 body {
-    font-family: 'Lato', sans-serif;
-    font-size: 16px;
-    background-color: #f4f4f4;
+    font-family: var(--font-body);
+    font-size: var(--font-size-base);
+    background-color: var(--color-background);
+    color: var(--color-text);
     margin: 0;
     padding: 0;
     display: flex;
@@ -10,105 +72,176 @@ body {
     min-height: 100vh;
 }
 
-.highlight {
-    color: #3c79dc;
-    text-align: center;
-    font-family: 'Lato', cursive;
-    font-weight: bold;
-    font-size: 1.2em;
-    margin-bottom: 20px;
+/* ============================================
+   LAYOUT
+   ============================================ */
 
+.container {
+    background-color: var(--color-surface);
+    padding: var(--space-xl);
+    border-radius: var(--border-radius-sm);
+    box-shadow: var(--shadow-card);
+    max-width: 800px;
+    width: 90%;
+}
+
+/* ============================================
+   TYPOGRAPHY
+   ============================================ */
+
+h1 {
+    color: var(--color-primary);
+    text-align: center;
+    font-family: var(--font-display);
+    font-size: var(--font-size-2xl);
+    font-weight: bold;
+    margin-bottom: 0;
+}
+
+h2 {
+    font-size: var(--font-size-xl);
+}
+
+h3 {
+    font-size: var(--font-size-lg);
+}
+
+p, ul, ol {
+    line-height: var(--line-height-base);
+}
+
+a {
+    color: var(--color-primary);
+    text-decoration: underline;
+}
+
+a:hover {
+    color: var(--color-primary-dark);
+}
+
+/* ============================================
+   COMPONENTS
+   ============================================ */
+
+/* Highlight Text */
+.highlight {
+    color: var(--color-primary);
+    text-align: center;
+    font-family: var(--font-body);
+    font-weight: bold;
+    font-size: var(--font-size-lg);
+    margin-bottom: var(--space-lg);
     display: inline-block;
     position: relative;
     left: 50%;
     transform: translateX(-50%);
 }
 
-.container {
-    background-color: white;
-    padding: 30px;
-    border-radius: 5px;
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
-    max-width: 800px;
-    width: 90%;
-}
-
-h1 {
-    color: #3c79dc;
-    text-align: center;
-    font-family: 'Pacifico', cursive;
-    font-size: 2.6em;
-    font-weight: bold;
-    margin-bottom: 0;
-}
-
-h2 {
-    font-size: 1.5em;
-}
-
+/* Logo */
 .logo {
     display: block;
-    margin: 20px auto 20px auto;
+    margin: var(--space-lg) auto var(--space-lg) auto;
     width: 100px;
 }
 
-p, ul, ol {
-    line-height: 1.6;
-}
-
+/* Lists */
 ul {
-    padding-left: 20px;
+    padding-left: var(--space-lg);
 }
 
 ul li {
     margin-bottom: 10px;
 }
 
-
+/* Developer Note Box */
 .developer-note {
-    background-color: #f4f4f4;
-    padding: 20px;
-    border-radius: 5px;
-    margin-top: 30px;
+    background-color: var(--color-surface-elevated);
+    padding: var(--space-lg);
+    border-radius: var(--border-radius-lg);
+    margin-top: var(--space-xl);
     font-size: 1em;
-    line-height: 1.6;
-
-    border-radius: 30px;
+    line-height: var(--line-height-base);
 }
 
 .developer-note h2 {
-    color: #3c79dc;
-    font-family: 'Protest Riot', cursive;
-    /* font-family: 'Lato', cursive; */
-    /* font-family: 'Lato', sans-serif; */
-    /* font-family: 'Pacifico', cursive; */
-    font-size: 1.5em;
+    color: var(--color-primary);
+    font-family: var(--font-heading);
+    font-size: var(--font-size-xl);
     text-align: center;
     margin-top: 0;
-    margin-bottom: 20px;
+    margin-bottom: var(--space-lg);
 }
 
 .developer-note p {
-    color: #333;
-    font-family: 'Lato', sans-serif;
+    color: var(--color-text);
+    font-family: var(--font-body);
 }
 
 .developer-note a {
-    /* color: #f4f4f4; */
-    color: #3c79dc;
+    color: var(--color-primary);
     text-decoration: underline;
 }
 
+/* How-To Images */
 .how-to-use-img {
    display: block;
    margin: 0 auto;
    padding: 10px;
 }
 
+/* Asterisk Style */
 .asterisk {
-    color: #3c79dc;
+    color: var(--color-primary);
 }
 
 .asterisk a {
     text-decoration: none;
+}
+
+/* ============================================
+   BUTTONS
+   ============================================ */
+
+.btn {
+    padding: 10px 32px;
+    border: none;
+    border-radius: var(--border-radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    background: var(--color-primary);
+    color: white;
+}
+
+.btn:hover {
+    background: var(--color-primary-dark);
+}
+
+/* ============================================
+   MESSAGE BOX (for warnings/notices)
+   ============================================ */
+
+.message {
+    background-color: var(--color-surface-elevated);
+    border: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-accent);
+    border-radius: var(--border-radius-sm);
+    padding: 14px;
+    margin-bottom: var(--space-md);
+}
+
+.message-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-sm);
+}
+
+.message-text {
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+    color: var(--color-text-muted);
 }

--- a/src/assets/shared.css
+++ b/src/assets/shared.css
@@ -26,8 +26,9 @@
     --color-border: rgba(0, 0, 0, 0.1);
     
     /* === TYPOGRAPHY === */
-    --font-display: 'Pacifico', cursive;
-    --font-heading: 'Protest Riot', cursive;
+    --font-heading-cursive: 'Pacifico', cursive;
+    --font-heading-cursive-alt: 'Protest Riot', cursive;
+    --font-heading: 'Lato', sans-serif;
     --font-body: 'Lato', sans-serif;
     --font-system: 'Segoe UI', system-ui, -apple-system, sans-serif;
     
@@ -92,7 +93,7 @@ body {
 h1 {
     color: var(--color-primary);
     text-align: center;
-    font-family: var(--font-display);
+    font-family: var(--font-heading-cursive);
     font-size: var(--font-size-2xl);
     font-weight: bold;
     margin-bottom: 0;
@@ -165,7 +166,7 @@ ul li {
 
 .developer-note h2 {
     color: var(--color-primary);
-    font-family: var(--font-heading);
+    font-family: var(--font-heading-cursive-alt);
     font-size: var(--font-size-xl);
     text-align: center;
     margin-top: 0;

--- a/src/assets/shared.css
+++ b/src/assets/shared.css
@@ -96,11 +96,12 @@ h1 {
     font-family: var(--font-heading-cursive);
     font-size: var(--font-size-2xl);
     font-weight: bold;
-    margin-bottom: 0;
+    margin: 0;
 }
 
 h2 {
     font-size: var(--font-size-xl);
+    color: var(--color-primary);
 }
 
 h3 {
@@ -138,11 +139,19 @@ a:hover {
     transform: translateX(-50%);
 }
 
+/* Header Layout */
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+}
+
 /* Logo */
 .logo {
-    display: block;
-    margin: var(--space-lg) auto var(--space-lg) auto;
-    width: 100px;
+    width: 64px;
+    height: 64px;
 }
 
 /* Lists */

--- a/src/assets/welcome.html
+++ b/src/assets/welcome.html
@@ -13,8 +13,10 @@
 </head>
 <body>
     <div class="container">
-        <img src="icon128.png" alt="Tab Renamer Logo" class="logo">
-        <h1>Welcome to Tab Renamer!</h1>
+        <div class="header">
+            <img src="icon128.png" alt="Tab Renamer Logo" class="logo">
+            <h1>Welcome to Tab Renamer!</h1>
+        </div>
         <p class="highlight">Customize your tab titles and favicons for a more organized browsing experience.</p>
 
         <h2>Key Features</h2>

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -224,6 +224,12 @@ chrome.runtime.onInstalled.addListener((details: chrome.runtime.InstalledDetails
             contexts: ["action"],
         });
 
+        chrome.contextMenus.create({
+            id: "changelogPage",
+            title: "View Changelog",
+            contexts: ["action"],
+        });
+
         if (details.reason === "install") {
             log.debug("onInstalled with reason = install triggered");
             welcomeTab = await chrome.tabs.create({url: chrome.runtime.getURL('assets/welcome.html')});
@@ -248,6 +254,9 @@ chrome.contextMenus.onClicked.addListener((info: chrome.contextMenus.OnClickData
     }
     if (info.menuItemId === "onboardingPage") {
         void chrome.tabs.create({ url: chrome.runtime.getURL('assets/welcome.html') });
+    }
+    if (info.menuItemId === "changelogPage") {
+        void chrome.tabs.create({ url: chrome.runtime.getURL('assets/changelog.html') });
     }
 });
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -14,7 +14,7 @@ const log = getLogger('background');
 const originalTitleStash: Record<number, string> = {};
 let welcomeTab: chrome.tabs.Tab | null = null;
 
-async function noContentScriptPopup() {
+async function showRenameUnavailablePopup() {
     try {
         await chrome.action.setPopup({ popup: 'popup/popup.html' });
         await chrome.action.openPopup();
@@ -23,8 +23,18 @@ async function noContentScriptPopup() {
             void chrome.action.setPopup({ popup: '' });
         }, 10);
     } catch (error) {
-        log.debug("Could not open the popup in noContentScriptPopup() function:", error);
+        log.debug("Could not open the popup in showRenameUnavailablePopup() function:", error);
         await chrome.action.setPopup({ popup: '' });
+    }
+}
+
+async function openRenameDialogOnTab(tabId: number) {
+    try {
+        log.debug('Sending open rename dialog command to tab:', tabId);
+        await chrome.tabs.sendMessage(tabId, { command: COMMAND_OPEN_RENAME_DIALOG });
+    } catch (error) {
+        log.debug('Failed to open rename dialog, showing fallback popup:', error);
+        await showRenameUnavailablePopup();
     }
 }
 
@@ -32,28 +42,15 @@ chrome.commands.onCommand.addListener((command) => {
     if (command === COMMAND_OPEN_RENAME_DIALOG) {
         log.debug('Received open rename dialog command.');
         chrome.tabs.query({active: true, currentWindow: true}).then(tabs => {
-            return chrome.tabs.sendMessage(tabs[0].id!, {
-                command: COMMAND_OPEN_RENAME_DIALOG,
-                tabId: tabs[0].id
-            });
+            void openRenameDialogOnTab(tabs[0].id!);
         }).catch(error => {
-            void noContentScriptPopup();
-            log.error('query error', error);
+            log.error('Failed to query active tab:', error);
         });
     }
 });
 
 chrome.action.onClicked.addListener((tab) => {
-    void (async () => {
-        try {
-            log.debug('COMMAND_OPEN_RENAME_DIALOG: Action clicked. Sending open rename dialog command to tab:', tab.id);
-            const result = await chrome.tabs.sendMessage(tab.id!, {command: COMMAND_OPEN_RENAME_DIALOG});
-            log.debug("COMMAND_OPEN_RENAME_DIALOG: Result from sending the command: ", result);
-        } catch (error) {
-            void noContentScriptPopup();
-            log.debug("COMMAND_OPEN_RENAME_DIALOG: Error: ", error);
-        }
-    })();
+    void openRenameDialogOnTab(tab.id!);
 });
 
 chrome.runtime.onMessage.addListener((message: any, sender: chrome.runtime.MessageSender, sendResponse: (response?: any) => void) => {
@@ -247,10 +244,7 @@ chrome.runtime.onInstalled.addListener((details: chrome.runtime.InstalledDetails
 
 chrome.contextMenus.onClicked.addListener((info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => {
     if (info.menuItemId === "renameTab") {
-        chrome.tabs.sendMessage(tab!.id!, {command: COMMAND_OPEN_RENAME_DIALOG})
-        .catch(err => {
-            void noContentScriptPopup();
-        });
+        void openRenameDialogOnTab(tab!.id!);
     }
     if (info.menuItemId === "onboardingPage") {
         void chrome.tabs.create({ url: chrome.runtime.getURL('assets/welcome.html') });

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -124,11 +124,7 @@
         <button id="closeBtn">Close</button>
     </div>
     
-    <script>
-        document.getElementById('closeBtn').addEventListener('click', () => {
-            window.close();
-        });
-    </script>
+    <script src="popup.js"></script>
 </body>
 </html>
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Tab Renamer</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+            width: 320px;
+            padding: 20px;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            color: #eee;
+        }
+        
+        .header {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 16px;
+            padding-bottom: 16px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        
+        .header img {
+            width: 32px;
+            height: 32px;
+        }
+        
+        .header h1 {
+            font-size: 18px;
+            font-weight: 600;
+            color: #fff;
+        }
+        
+        .message {
+            background: rgba(255, 193, 7, 0.15);
+            border: 1px solid rgba(255, 193, 7, 0.3);
+            border-radius: 8px;
+            padding: 14px;
+            margin-bottom: 16px;
+        }
+        
+        .message-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-weight: 600;
+            color: #ffc107;
+            margin-bottom: 8px;
+        }
+        
+        .message-text {
+            font-size: 13px;
+            line-height: 1.5;
+            color: #ccc;
+        }
+        
+        .reasons {
+            font-size: 12px;
+            color: #999;
+            margin-top: 12px;
+        }
+        
+        .reasons ul {
+            margin-top: 6px;
+            margin-left: 16px;
+        }
+        
+        .reasons li {
+            margin-bottom: 4px;
+        }
+        
+        .actions {
+            display: flex;
+            justify-content: center;
+        }
+        
+        button {
+            padding: 10px 32px;
+            border: none;
+            border-radius: 6px;
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.15s ease;
+            background: #4f46e5;
+            color: white;
+        }
+        
+        button:hover {
+            background: #4338ca;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <img src="../assets/icon48.png" alt="Tab Renamer">
+        <h1>Tab Renamer</h1>
+    </div>
+    
+    <div class="message">
+        <div class="message-title">
+            ⚠️ Cannot rename this tab
+        </div>
+        <div class="message-text">
+            Tab Renamer can't run on this page, since extension access to this page is restricted by Chrome.
+        </div>
+        <div class="reasons">
+            Common restricted pages:
+            <ul>
+                <li>chrome:// pages (newtab, settings, extensions, etc.)</li>
+                <li>Chrome Web Store related pages</li>
+            </ul>
+        </div>
+    </div>
+    
+    <div class="actions">
+        <button id="closeBtn">Close</button>
+    </div>
+    
+    <script>
+        document.getElementById('closeBtn').addEventListener('click', () => {
+            window.close();
+        });
+    </script>
+</body>
+</html>
+

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -3,6 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Tab Renamer</title>
+    <link rel="stylesheet" type="text/css" href="../assets/shared.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
     <style>
         * {
             margin: 0;
@@ -11,20 +16,19 @@
         }
         
         body {
-            font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
             width: 320px;
-            padding: 20px;
-            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-            color: #eee;
+            padding: var(--space-lg);
+            min-height: auto;
+            display: block;
         }
         
         .header {
             display: flex;
             align-items: center;
             gap: 12px;
-            margin-bottom: 16px;
-            padding-bottom: 16px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            margin-bottom: var(--space-md);
+            padding-bottom: var(--space-md);
+            border-bottom: 1px solid var(--color-border);
         }
         
         .header img {
@@ -34,67 +38,29 @@
         
         .header h1 {
             font-size: 18px;
-            font-weight: 600;
-            color: #fff;
-        }
-        
-        .message {
-            background: rgba(255, 193, 7, 0.15);
-            border: 1px solid rgba(255, 193, 7, 0.3);
-            border-radius: 8px;
-            padding: 14px;
-            margin-bottom: 16px;
-        }
-        
-        .message-title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-weight: 600;
-            color: #ffc107;
-            margin-bottom: 8px;
-        }
-        
-        .message-text {
-            font-size: 13px;
-            line-height: 1.5;
-            color: #ccc;
+            text-align: left;
+            margin: 0;
         }
         
         .reasons {
-            font-size: 12px;
-            color: #999;
+            font-size: var(--font-size-xs);
+            color: var(--color-text-light);
             margin-top: 12px;
         }
         
         .reasons ul {
             margin-top: 6px;
-            margin-left: 16px;
+            margin-left: var(--space-md);
+            padding-left: 0;
         }
         
         .reasons li {
-            margin-bottom: 4px;
+            margin-bottom: var(--space-xs);
         }
         
         .actions {
             display: flex;
             justify-content: center;
-        }
-        
-        button {
-            padding: 10px 32px;
-            border: none;
-            border-radius: 6px;
-            font-size: 13px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.15s ease;
-            background: #4f46e5;
-            color: white;
-        }
-        
-        button:hover {
-            background: #4338ca;
         }
     </style>
 </head>
@@ -106,25 +72,27 @@
     
     <div class="message">
         <div class="message-title">
-            ⚠️ Cannot rename this tab
+            ⚠️ Cannot rename this tab 
         </div>
         <div class="message-text">
-            Tab Renamer can't run on this page, since extension access to this page is restricted by Chrome.
+            Sorry! But Tab Renamer can't run on this tab since Chrome restricts access to certain special pages. 😢
         </div>
         <div class="reasons">
             Common restricted pages:
             <ul>
-                <li>chrome:// pages (newtab, settings, extensions, etc.)</li>
+                <li>chrome:// pages, such as newtab, settings, extensions, etc. (chrome://newtab)</li>
                 <li>Chrome Web Store related pages</li>
             </ul>
+        </div>
+        <div class="message-text">
+            Feel free to try the extension on other pages!
         </div>
     </div>
     
     <div class="actions">
-        <button id="closeBtn">Close</button>
+        <button id="closeBtn" class="btn">Close</button>
     </div>
     
     <script src="popup.js"></script>
 </body>
 </html>
-

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" type="text/css" href="../assets/shared.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
     <style>
         * {
@@ -37,6 +36,7 @@
         }
         
         .header h1 {
+            font-family: var(--font-heading);
             font-size: 18px;
             text-align: left;
             margin: 0;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,0 +1,4 @@
+document.getElementById('closeBtn').addEventListener('click', () => {
+    window.close();
+});
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,6 +124,7 @@ module.exports = (_env, argv) => {
                     },
                 },
                 { from: path.resolve(__dirname, 'src/settings/settings.html'), to: 'settings/settings.html' },
+                { from: path.resolve(__dirname, 'src/popup/popup.html'), to: 'popup/popup.html' },
             ],
         }),
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,7 +124,7 @@ module.exports = (_env, argv) => {
                     },
                 },
                 { from: path.resolve(__dirname, 'src/settings/settings.html'), to: 'settings/settings.html' },
-                { from: path.resolve(__dirname, 'src/popup/popup.html'), to: 'popup/popup.html' },
+                { from: path.resolve(__dirname, 'src/popup/'), to: 'popup/' },
             ],
         }),
         ],


### PR DESCRIPTION
## Add Fallback Popup for Chrome-Restricted Pages

### Changes

**Improvement: Restricted Page Popup**
- When users try to rename tabs on pages where Chrome restricts extension access (like `chrome://` pages or the Chrome Web Store), the extension now shows an informative popup instead of silently failing.
- Explains to users why certain pages can't be renamed and lists common restricted page types

**Context Menu Enhancement**
- Added "View Changelog" option to the extension's context menu

**Design System Improvements**
- Refactored `shared.css` to use CSS variables for consistent theming (colors, typography, spacing)